### PR TITLE
Report with timestamp rather than date

### DIFF
--- a/mbc-userAPI-campaignActivity.php
+++ b/mbc-userAPI-campaignActivity.php
@@ -42,10 +42,10 @@ class MBC_UserAPICampaignActivity
 
     // Campaign signup or reportback?
     if ($payloadDetails['activity'] == 'campaign_reportback') {
-      $post['campaigns'][0]['reportback'] = date('m-d-Y', $payloadDetails['activity_timestamp']);
+      $post['campaigns'][0]['reportback'] = $payloadDetails['activity_timestamp'];
     }
     else {
-      $post['campaigns'][0]['signup'] = date('m-d-Y', $payloadDetails['activity_timestamp']);
+      $post['campaigns'][0]['signup'] = $payloadDetails['activity_timestamp'];
     }
 
     $userApiUrl = getenv('DS_USER_API_HOST') . ':' . getenv('DS_USER_API_PORT') . '/user';


### PR DESCRIPTION
Fixes #7 

See also:
https://github.com/DoSomething/mb-users-api/issues/52

mb-user-api expect signups and reportbacks as timestamp rather than dates.
